### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -1,5 +1,8 @@
 name: Lint Code with golangci-lint
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/umatare5/controld-exporter/security/code-scanning/3](https://github.com/umatare5/controld-exporter/security/code-scanning/3)

To fix the issue, add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. In this case, the workflow primarily reads repository contents and does not perform any write operations. Therefore, the `contents: read` permission is sufficient.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the `lint` job to limit permissions specifically for that job. Adding it at the root level is recommended for simplicity and consistency.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
