### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tagging.yaml
+++ b/.github/workflows/tagging.yaml
@@ -1,4 +1,6 @@
 name: Update Tag on VERSION Change
+permissions:
+  contents: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/umatare5/controld-exporter/security/code-scanning/1](https://github.com/umatare5/controld-exporter/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow or the specific job. Since the only action requiring elevated permissions is pushing a tag (which requires `contents: write`), set `contents: write` as the minimal required permission. This can be done at the workflow level (applies to all jobs) or at the job level (applies only to the `update-tag` job). For clarity and minimal privilege, add the following at the top level of the workflow (just after the `name:` line and before `on:`):

```yaml
permissions:
  contents: write
```

No additional imports or definitions are needed. Only the YAML file needs to be edited.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
