### PR TITLE
Fix `failed to load package goarch` when run golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -5,38 +5,13 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   lint:
-    name: Run golangci-lint
-    runs-on: ubuntu-24.04
-
-    steps:
-      # Checkout the code
-      - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      # Set up Go environment
-      - name: Set up Go
-        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
-        with:
-          go-version: "1.24"
-
-      # Cache golangci-lint binary for faster execution
-      - name: Cache golangci-lint
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
-        with:
-          path: ~/.cache/golangci-lint
-          key: golangci-lint-${{ runner.os }}-${{ hashFiles('.golangci.yml') }}
-          restore-keys: |
-            golangci-lint-${{ runner.os }}-
-
-      # Install golangci-lint
-      - name: Install golangci-lint
-        run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.54.2
-
-      # Run golangci-lint
-      - name: Run golangci-lint
-        run: |
-          go mod tidy
-          golangci-lint run --timeout 5m
+    uses: umatare5/common/.github/workflows/golangci-lint.yml@0588daa41adfcb4187551c931dba237600f9fa01
+    with:
+      go_version: "1.24.5"
+      golangci_lint_version: "v1.64.8"
+      golangci_lint_config: ".golangci.yml"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,57 +2,34 @@
 # More information: https://golangci-lint.run/usage/configuration/
 
 run:
-  # All linters (as a shortcut to quickly enable everything)
-  linters:
-    enable-all: false
-  # Enable specific linters (you can customize this based on your needs)
-  enabled:
+  timeout: 5m
+  # Removed modules-download-mode to allow flexible module operations
+
+linters:
+  enable:
     - govet              # Reports suspicious constructs
-    - structcheck        # Unused struct field detector
     - errcheck           # Check for unhandled errors
     - gosimple           # Simplify your Go code
     - staticcheck        # Comprehensive static analysis
     - ineffassign        # Detects ineffective assignments
     - unused             # Finds unused variables
-    - deadcode           # Finds unused code
-    - typecheck          # Go "types" system checks
-    - gofmt              # Checks gofmt formatting
-    - misspell           # Detect spelling errors
-    - gocyclo            # Cyclomatic complexity check
-    - lll                # Long line linter
-  # Exclude specific default linters if you want
-  disabled:
-    - scopelint          # (Optional) Scope-specific checks that may be noisy
 
 # Settings for specific linters
 linters-settings:
-  gocyclo:
-    min-complexity: 15    # Set the threshold for cyclomatic complexity
-  misspell:
-    locale: US            # Ensure spell checks in American English
-  lll:
-    line-length: 100 # Set the maximum line length to 100 characters
+  errcheck:
+    check-type-assertions: true
+    check-blank: false
 
 issues:
-  # Exclude specific warning types (refine as needed in your project)
+  # Exclude specific warning types
   exclude-rules:
     - linters:
         - gocyclo
-      text: "cyclomatic complexity"
+      text: "(?i)cyclomatic complexity"
   exclude-use-default: false
-  severity: warning
 
 # Files and folders to ignore
-exclude:
-  - vendor/               # Ignore vendor directory
-  - build/                # Ignore build outputs
-  - testdata/             # Ignore test data
-
-build:
-  goos: [linux, darwin, windows]  # Cross-platform development focus
-  goarch: [amd64, arm64]
-
-# Advanced settings for caching
-cache:
-  max-size: 512mb
-  max-age: 0 # Set to "0" to not expire caches
+skip-dirs:
+  - vendor
+  - build
+  - tmp

--- a/internal/collector/main.go
+++ b/internal/collector/main.go
@@ -244,8 +244,5 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 
 // isRunningInPersonalMode checks if the collector is running in personal mode.
 func (c *Collector) isRunningInPersonalMode() bool {
-	if c.businessModeEnabled {
-		return false
-	}
-	return true
+	return !(c.businessModeEnabled)
 }


### PR DESCRIPTION
## WHAT

SSIA.

## WHY

golangci-lint failed because `failed to load package goarch`.

- Ref. https://github.com/umatare5/controld-exporter/pull/7

<img width="1658" height="976" alt="Screenshot 2025-07-27 at 23 52 23" src="https://github.com/user-attachments/assets/3bf86460-d8b2-405b-ae8f-1306ec6e167a" />

